### PR TITLE
feat(client): add new category client component

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,7 @@ CHANGELOG.md
 lerna.json
 
 # react-toolkit-all
+packages/all/src/bootstrap/af-components-client.template.scss
 packages/all/src/bootstrap/af-components.template.scss
 packages/all/src/bootstrap/af-toolkit-core.template.scss
 packages/all/component

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,6 +27,7 @@ module.exports = {
     '../packages/Form/Input/textarea/src/*.stories.@(ts|tsx|js)',
     '../packages/Form/steps/src/*.stories.@(ts|tsx|js)',
     '../packages/Form/summary/src/*.stories.@(ts|tsx|js)',
+    '../packages/header-client-app/src/*.stories.@(ts|tsx|js)',
     '../packages/help/src/*.stories.@(ts|tsx|js)',
     '../packages/helpinfo/src/*.stories.@(ts|tsx|js)',
     '../packages/highlight/src/*.stories.@(ts|tsx|js)',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,9 @@ import { addReadme } from 'storybook-readme';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import '../packages/all/dist/style/af-toolkit-core.css';
+import '../packages/all/dist/style/af-components-client.css';
 import '../packages/core/dist/assets/fonts/icons/af-icons.css';
+import '@fontsource/material-icons';
 import './storybook.css';
 
 export const decorators = [addReadme];

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -1,6 +1,3 @@
-#root {
-  padding: 2rem;
-}
 #root > div > div {
   text-align: left !important;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "packages/Modal/*"
       ],
       "dependencies": {
+        "@fontsource/material-icons": "^4.5.4",
         "@popperjs/core": "^2.11.6",
         "autoprefixer": "10.0.1",
         "clean-css": "4.2.3",
@@ -2592,6 +2593,11 @@
       "bin": {
         "which": "bin/which"
       }
+    },
+    "node_modules/@fontsource/material-icons": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-4.5.4.tgz",
+      "integrity": "sha512-YGmXkkEdu6EIgpFKNmB/nIXzZocwSmbI01Ninpmml8x8BT0M6RR++V1KqOfpzZ6Cw/FQ2/KYonQ3x4IY/4VRRA=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -35526,6 +35532,7 @@
       }
     },
     "packages/helpinfo": {
+      "name": "@axa-fr/react-toolkit-helpinfo",
       "version": "2.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {
@@ -37580,6 +37587,11 @@
           }
         }
       }
+    },
+    "@fontsource/material-icons": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-4.5.4.tgz",
+      "integrity": "sha512-YGmXkkEdu6EIgpFKNmB/nIXzZocwSmbI01Ninpmml8x8BT0M6RR++V1KqOfpzZ6Cw/FQ2/KYonQ3x4IY/4VRRA=="
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "packages/Modal/*"
       ],
       "dependencies": {
-        "@fontsource/material-icons": "^4.5.4",
-        "@popperjs/core": "^2.11.6",
+        "@fontsource/material-icons": "4.5.4",
+        "@popperjs/core": "2.11.6",
         "autoprefixer": "10.0.1",
         "clean-css": "4.2.3",
         "find": "0.3.0"
@@ -195,6 +195,10 @@
     },
     "node_modules/@axa-fr/react-toolkit-form-summary": {
       "resolved": "packages/Form/summary",
+      "link": true
+    },
+    "node_modules/@axa-fr/react-toolkit-header-client-app": {
+      "resolved": "packages/header-client-app",
       "link": true
     },
     "node_modules/@axa-fr/react-toolkit-help": {
@@ -35181,6 +35185,7 @@
         "@axa-fr/react-toolkit-form-input-textarea": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-form-steps": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-form-summary": "2.0.1-alpha.0",
+        "@axa-fr/react-toolkit-header-client-app": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-help": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-helpinfo": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-highlight": "2.0.1-alpha.0",
@@ -35518,6 +35523,17 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "packages/header-client-app": {
+      "version": "2.0.1-alpha.0",
+      "license": "MIT",
+      "dependencies": {
+        "@axa-fr/react-toolkit-core": "2.0.1-alpha.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "packages/help": {
       "name": "@axa-fr/react-toolkit-help",
       "version": "2.0.1-alpha.0",
@@ -35809,6 +35825,7 @@
         "@axa-fr/react-toolkit-form-input-textarea": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-form-steps": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-form-summary": "2.0.1-alpha.0",
+        "@axa-fr/react-toolkit-header-client-app": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-help": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-helpinfo": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-highlight": "2.0.1-alpha.0",
@@ -35997,6 +36014,12 @@
       "version": "file:packages/Form/summary",
       "requires": {
         "@axa-fr/react-toolkit-alert": "2.0.1-alpha.0",
+        "@axa-fr/react-toolkit-core": "2.0.1-alpha.0"
+      }
+    },
+    "@axa-fr/react-toolkit-header-client-app": {
+      "version": "file:packages/header-client-app",
+      "requires": {
         "@axa-fr/react-toolkit-core": "2.0.1-alpha.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@popperjs/core": "^2.11.6",
+    "@fontsource/material-icons": "4.5.4",
+    "@popperjs/core": "2.11.6",
     "autoprefixer": "10.0.1",
     "clean-css": "4.2.3",
     "find": "0.3.0"

--- a/packages/Form/Input/card/src/CardCheckbox.stories.tsx
+++ b/packages/Form/Input/card/src/CardCheckbox.stories.tsx
@@ -9,7 +9,7 @@ import CardFooter from './CardFooter';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Card',
+  title: 'Agent/Form elements/Card',
   component: Card,
   parameters: {
     readme: {

--- a/packages/Form/Input/card/src/CardRadio.stories.tsx
+++ b/packages/Form/Input/card/src/CardRadio.stories.tsx
@@ -9,7 +9,7 @@ import CardFooter from './CardFooter';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Card',
+  title: 'Agent/Form elements/Card',
   component: CardGroupRadio,
   parameters: {
     readme: {

--- a/packages/Form/Input/checkbox/src/CheckboxInput.stories.tsx
+++ b/packages/Form/Input/checkbox/src/CheckboxInput.stories.tsx
@@ -28,7 +28,7 @@ const options = [
 const values = ['1', '3'];
 
 export default {
-  title: 'Form elements/Checkbox',
+  title: 'Agent/Form elements/Checkbox',
   component: CheckboxInput,
   parameters: {
     readme: {

--- a/packages/Form/Input/choice/src/ChoiceInput.stories.tsx
+++ b/packages/Form/Input/choice/src/ChoiceInput.stories.tsx
@@ -6,7 +6,7 @@ import Choice from './Choice';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Choice',
+  title: 'Agent/Form elements/Choice',
   component: Choice,
   parameters: {
     readme: {

--- a/packages/Form/Input/date/src/Date.stories.tsx
+++ b/packages/Form/Input/date/src/Date.stories.tsx
@@ -6,7 +6,7 @@ import DateInput from './DateInput';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Date',
+  title: 'Agent/Form elements/Date',
   component: CustomDate,
   parameters: {
     readme: {

--- a/packages/Form/Input/file/src/FileInput.stories.tsx
+++ b/packages/Form/Input/file/src/FileInput.stories.tsx
@@ -8,7 +8,7 @@ import FileTable from './FileTable';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/File',
+  title: 'Agent/Form elements/File',
   component: FileInput,
   parameters: {
     readme: {

--- a/packages/Form/Input/number/src/NumberInput.stories.tsx
+++ b/packages/Form/Input/number/src/NumberInput.stories.tsx
@@ -8,7 +8,7 @@ import NumberInput from './NumberInput';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Number',
+  title: 'Agent/Form elements/Number',
   component: Number,
   argTypes: {},
   parameters: {

--- a/packages/Form/Input/pass/src/Pass.stories.tsx
+++ b/packages/Form/Input/pass/src/Pass.stories.tsx
@@ -4,7 +4,7 @@ import Pass from './Pass';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Pass',
+  title: 'Agent/Form elements/Pass',
   component: Pass,
   parameters: {
     readme: {

--- a/packages/Form/Input/pass/src/PassInput.stories.tsx
+++ b/packages/Form/Input/pass/src/PassInput.stories.tsx
@@ -6,7 +6,7 @@ import PassInput from './PassInput';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Pass',
+  title: 'Agent/Form elements/Pass',
   component: PassInput,
   parameters: {
     readme: {

--- a/packages/Form/Input/radio/src/Radio.stories.tsx
+++ b/packages/Form/Input/radio/src/Radio.stories.tsx
@@ -4,7 +4,7 @@ import { Radio, RadioModes } from '.';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Radio',
+  title: 'Agent/Form elements/Radio',
   parameters: {
     readme: {
       sidebar: readme,

--- a/packages/Form/Input/radio/src/RadioInput.stories.tsx
+++ b/packages/Form/Input/radio/src/RadioInput.stories.tsx
@@ -7,7 +7,7 @@ import readme from '../README.md';
 import { RadioModes } from './Radio';
 
 export default {
-  title: 'Form elements/Radio',
+  title: 'Agent/Form elements/Radio',
   component: RadioInput,
   parameters: {
     readme: {

--- a/packages/Form/Input/radio/src/RadioItem.stories.tsx
+++ b/packages/Form/Input/radio/src/RadioItem.stories.tsx
@@ -4,7 +4,7 @@ import RadioItem from './RadioItem';
 import readme from '../README.md';
 
 export default {
-  title: 'Components low level/Radio/RadioItem',
+  title: 'Agent/Components low level/Radio/RadioItem',
   component: RadioItem,
   parameters: {
     readme: {

--- a/packages/Form/Input/select-multi/src/MultiSelect.stories.tsx
+++ b/packages/Form/Input/select-multi/src/MultiSelect.stories.tsx
@@ -6,7 +6,7 @@ import MultiSelectInput from './MultiSelectInput';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/SelectMulti',
+  title: 'Agent/Form elements/SelectMulti',
   component: MultiSelect,
   parameters: {
     readme: {

--- a/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelect.spec.tsx.snap
+++ b/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelect.spec.tsx.snap
@@ -16,22 +16,22 @@ exports[`renders MultiSelect correctly 1`] = `
       class="css-1f43avz-a11yText-A11yText"
     />
     <div
-      class=" css-13cymwt-control"
+      class=" css-1s2u09g-control"
     >
       <div
-        class=" css-3w2yfm-ValueContainer"
+        class=" css-g1d714-ValueContainer"
       >
         <div
-          class=" css-1p3m7a8-multiValue"
+          class="css-1rhbuit-multiValue"
         >
           <div
-            class=" css-wsp0cs-MultiValueGeneric"
+            class="css-12jo7m5"
           >
             For fun
           </div>
           <div
             aria-label="Remove For fun"
-            class=" css-12a83d4-MultiValueRemove"
+            class="css-xb97g8"
             role="button"
           >
             <svg
@@ -49,16 +49,16 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class=" css-1p3m7a8-multiValue"
+          class="css-1rhbuit-multiValue"
         >
           <div
-            class=" css-wsp0cs-MultiValueGeneric"
+            class="css-12jo7m5"
           >
             For drink
           </div>
           <div
             aria-label="Remove For drink"
-            class=" css-12a83d4-MultiValueRemove"
+            class="css-xb97g8"
             role="button"
           >
             <svg
@@ -76,7 +76,7 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class=" css-qbdosj-Input"
+          class=" css-6j8wv5-Input"
           data-value=""
         >
           <input
@@ -102,7 +102,7 @@ exports[`renders MultiSelect correctly 1`] = `
       >
         <div
           aria-hidden="true"
-          class=" css-1xc3v61-indicatorContainer"
+          class=" css-tlfecz-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -118,11 +118,11 @@ exports[`renders MultiSelect correctly 1`] = `
           </svg>
         </div>
         <span
-          class=" css-1u9des2-indicatorSeparator"
+          class=" css-1okebmr-indicatorSeparator"
         />
         <div
           aria-hidden="true"
-          class=" css-1xc3v61-indicatorContainer"
+          class=" css-tlfecz-indicatorContainer"
         >
           <svg
             aria-hidden="true"

--- a/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelect.spec.tsx.snap
+++ b/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelect.spec.tsx.snap
@@ -16,22 +16,22 @@ exports[`renders MultiSelect correctly 1`] = `
       class="css-1f43avz-a11yText-A11yText"
     />
     <div
-      class=" css-1s2u09g-control"
+      class=" css-13cymwt-control"
     >
       <div
-        class=" css-g1d714-ValueContainer"
+        class=" css-3w2yfm-ValueContainer"
       >
         <div
-          class="css-1rhbuit-multiValue"
+          class=" css-1p3m7a8-multiValue"
         >
           <div
-            class="css-12jo7m5"
+            class=" css-wsp0cs-MultiValueGeneric"
           >
             For fun
           </div>
           <div
             aria-label="Remove For fun"
-            class="css-xb97g8"
+            class=" css-12a83d4-MultiValueRemove"
             role="button"
           >
             <svg
@@ -49,16 +49,16 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class="css-1rhbuit-multiValue"
+          class=" css-1p3m7a8-multiValue"
         >
           <div
-            class="css-12jo7m5"
+            class=" css-wsp0cs-MultiValueGeneric"
           >
             For drink
           </div>
           <div
             aria-label="Remove For drink"
-            class="css-xb97g8"
+            class=" css-12a83d4-MultiValueRemove"
             role="button"
           >
             <svg
@@ -76,7 +76,7 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class=" css-6j8wv5-Input"
+          class=" css-qbdosj-Input"
           data-value=""
         >
           <input
@@ -102,7 +102,7 @@ exports[`renders MultiSelect correctly 1`] = `
       >
         <div
           aria-hidden="true"
-          class=" css-tlfecz-indicatorContainer"
+          class=" css-1xc3v61-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -118,11 +118,11 @@ exports[`renders MultiSelect correctly 1`] = `
           </svg>
         </div>
         <span
-          class=" css-1okebmr-indicatorSeparator"
+          class=" css-1u9des2-indicatorSeparator"
         />
         <div
           aria-hidden="true"
-          class=" css-tlfecz-indicatorContainer"
+          class=" css-1xc3v61-indicatorContainer"
         >
           <svg
             aria-hidden="true"

--- a/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelectInput.spec.tsx.snap
+++ b/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelectInput.spec.tsx.snap
@@ -16,22 +16,22 @@ exports[`renders MultiSelect correctly 1`] = `
       class="css-1f43avz-a11yText-A11yText"
     />
     <div
-      class=" css-1s2u09g-control"
+      class=" css-13cymwt-control"
     >
       <div
-        class=" css-g1d714-ValueContainer"
+        class=" css-3w2yfm-ValueContainer"
       >
         <div
-          class="css-1rhbuit-multiValue"
+          class=" css-1p3m7a8-multiValue"
         >
           <div
-            class="css-12jo7m5"
+            class=" css-wsp0cs-MultiValueGeneric"
           >
             For fun
           </div>
           <div
             aria-label="Remove For fun"
-            class="css-xb97g8"
+            class=" css-12a83d4-MultiValueRemove"
             role="button"
           >
             <svg
@@ -49,16 +49,16 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class="css-1rhbuit-multiValue"
+          class=" css-1p3m7a8-multiValue"
         >
           <div
-            class="css-12jo7m5"
+            class=" css-wsp0cs-MultiValueGeneric"
           >
             For drink
           </div>
           <div
             aria-label="Remove For drink"
-            class="css-xb97g8"
+            class=" css-12a83d4-MultiValueRemove"
             role="button"
           >
             <svg
@@ -76,7 +76,7 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class=" css-6j8wv5-Input"
+          class=" css-qbdosj-Input"
           data-value=""
         >
           <input
@@ -102,7 +102,7 @@ exports[`renders MultiSelect correctly 1`] = `
       >
         <div
           aria-hidden="true"
-          class=" css-tlfecz-indicatorContainer"
+          class=" css-1xc3v61-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -118,11 +118,11 @@ exports[`renders MultiSelect correctly 1`] = `
           </svg>
         </div>
         <span
-          class=" css-1okebmr-indicatorSeparator"
+          class=" css-1u9des2-indicatorSeparator"
         />
         <div
           aria-hidden="true"
-          class=" css-tlfecz-indicatorContainer"
+          class=" css-1xc3v61-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -191,22 +191,22 @@ exports[`renders MultiSelectInput correctly 1`] = `
             class="css-1f43avz-a11yText-A11yText"
           />
           <div
-            class=" css-1s2u09g-control"
+            class=" css-13cymwt-control"
           >
             <div
-              class=" css-g1d714-ValueContainer"
+              class=" css-3w2yfm-ValueContainer"
             >
               <div
-                class="css-1rhbuit-multiValue"
+                class=" css-1p3m7a8-multiValue"
               >
                 <div
-                  class="css-12jo7m5"
+                  class=" css-wsp0cs-MultiValueGeneric"
                 >
                   For fun
                 </div>
                 <div
                   aria-label="Remove For fun"
-                  class="css-xb97g8"
+                  class=" css-12a83d4-MultiValueRemove"
                   role="button"
                 >
                   <svg
@@ -224,16 +224,16 @@ exports[`renders MultiSelectInput correctly 1`] = `
                 </div>
               </div>
               <div
-                class="css-1rhbuit-multiValue"
+                class=" css-1p3m7a8-multiValue"
               >
                 <div
-                  class="css-12jo7m5"
+                  class=" css-wsp0cs-MultiValueGeneric"
                 >
                   For drink
                 </div>
                 <div
                   aria-label="Remove For drink"
-                  class="css-xb97g8"
+                  class=" css-12a83d4-MultiValueRemove"
                   role="button"
                 >
                   <svg
@@ -251,7 +251,7 @@ exports[`renders MultiSelectInput correctly 1`] = `
                 </div>
               </div>
               <div
-                class=" css-6j8wv5-Input"
+                class=" css-qbdosj-Input"
                 data-value=""
               >
                 <input
@@ -277,7 +277,7 @@ exports[`renders MultiSelectInput correctly 1`] = `
             >
               <div
                 aria-hidden="true"
-                class=" css-tlfecz-indicatorContainer"
+                class=" css-1xc3v61-indicatorContainer"
               >
                 <svg
                   aria-hidden="true"
@@ -293,11 +293,11 @@ exports[`renders MultiSelectInput correctly 1`] = `
                 </svg>
               </div>
               <span
-                class=" css-1okebmr-indicatorSeparator"
+                class=" css-1u9des2-indicatorSeparator"
               />
               <div
                 aria-hidden="true"
-                class=" css-tlfecz-indicatorContainer"
+                class=" css-1xc3v61-indicatorContainer"
               >
                 <svg
                   aria-hidden="true"

--- a/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelectInput.spec.tsx.snap
+++ b/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelectInput.spec.tsx.snap
@@ -16,22 +16,22 @@ exports[`renders MultiSelect correctly 1`] = `
       class="css-1f43avz-a11yText-A11yText"
     />
     <div
-      class=" css-13cymwt-control"
+      class=" css-1s2u09g-control"
     >
       <div
-        class=" css-3w2yfm-ValueContainer"
+        class=" css-g1d714-ValueContainer"
       >
         <div
-          class=" css-1p3m7a8-multiValue"
+          class="css-1rhbuit-multiValue"
         >
           <div
-            class=" css-wsp0cs-MultiValueGeneric"
+            class="css-12jo7m5"
           >
             For fun
           </div>
           <div
             aria-label="Remove For fun"
-            class=" css-12a83d4-MultiValueRemove"
+            class="css-xb97g8"
             role="button"
           >
             <svg
@@ -49,16 +49,16 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class=" css-1p3m7a8-multiValue"
+          class="css-1rhbuit-multiValue"
         >
           <div
-            class=" css-wsp0cs-MultiValueGeneric"
+            class="css-12jo7m5"
           >
             For drink
           </div>
           <div
             aria-label="Remove For drink"
-            class=" css-12a83d4-MultiValueRemove"
+            class="css-xb97g8"
             role="button"
           >
             <svg
@@ -76,7 +76,7 @@ exports[`renders MultiSelect correctly 1`] = `
           </div>
         </div>
         <div
-          class=" css-qbdosj-Input"
+          class=" css-6j8wv5-Input"
           data-value=""
         >
           <input
@@ -102,7 +102,7 @@ exports[`renders MultiSelect correctly 1`] = `
       >
         <div
           aria-hidden="true"
-          class=" css-1xc3v61-indicatorContainer"
+          class=" css-tlfecz-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -118,11 +118,11 @@ exports[`renders MultiSelect correctly 1`] = `
           </svg>
         </div>
         <span
-          class=" css-1u9des2-indicatorSeparator"
+          class=" css-1okebmr-indicatorSeparator"
         />
         <div
           aria-hidden="true"
-          class=" css-1xc3v61-indicatorContainer"
+          class=" css-tlfecz-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -191,22 +191,22 @@ exports[`renders MultiSelectInput correctly 1`] = `
             class="css-1f43avz-a11yText-A11yText"
           />
           <div
-            class=" css-13cymwt-control"
+            class=" css-1s2u09g-control"
           >
             <div
-              class=" css-3w2yfm-ValueContainer"
+              class=" css-g1d714-ValueContainer"
             >
               <div
-                class=" css-1p3m7a8-multiValue"
+                class="css-1rhbuit-multiValue"
               >
                 <div
-                  class=" css-wsp0cs-MultiValueGeneric"
+                  class="css-12jo7m5"
                 >
                   For fun
                 </div>
                 <div
                   aria-label="Remove For fun"
-                  class=" css-12a83d4-MultiValueRemove"
+                  class="css-xb97g8"
                   role="button"
                 >
                   <svg
@@ -224,16 +224,16 @@ exports[`renders MultiSelectInput correctly 1`] = `
                 </div>
               </div>
               <div
-                class=" css-1p3m7a8-multiValue"
+                class="css-1rhbuit-multiValue"
               >
                 <div
-                  class=" css-wsp0cs-MultiValueGeneric"
+                  class="css-12jo7m5"
                 >
                   For drink
                 </div>
                 <div
                   aria-label="Remove For drink"
-                  class=" css-12a83d4-MultiValueRemove"
+                  class="css-xb97g8"
                   role="button"
                 >
                   <svg
@@ -251,7 +251,7 @@ exports[`renders MultiSelectInput correctly 1`] = `
                 </div>
               </div>
               <div
-                class=" css-qbdosj-Input"
+                class=" css-6j8wv5-Input"
                 data-value=""
               >
                 <input
@@ -277,7 +277,7 @@ exports[`renders MultiSelectInput correctly 1`] = `
             >
               <div
                 aria-hidden="true"
-                class=" css-1xc3v61-indicatorContainer"
+                class=" css-tlfecz-indicatorContainer"
               >
                 <svg
                   aria-hidden="true"
@@ -293,11 +293,11 @@ exports[`renders MultiSelectInput correctly 1`] = `
                 </svg>
               </div>
               <span
-                class=" css-1u9des2-indicatorSeparator"
+                class=" css-1okebmr-indicatorSeparator"
               />
               <div
                 aria-hidden="true"
-                class=" css-1xc3v61-indicatorContainer"
+                class=" css-tlfecz-indicatorContainer"
               >
                 <svg
                   aria-hidden="true"

--- a/packages/Form/Input/select/src/Select.stories.tsx
+++ b/packages/Form/Input/select/src/Select.stories.tsx
@@ -14,7 +14,7 @@ const options = [
 ];
 
 export default {
-  title: 'Form elements/Select',
+  title: 'Agent/Form elements/Select',
   component: Select,
   argTypes: {
     onChange: { action: 'onChange' },

--- a/packages/Form/Input/select/src/SelectBase.stories.tsx
+++ b/packages/Form/Input/select/src/SelectBase.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react';
 import SelectBase from './SelectBase';
 
 export default {
-  title: 'Components low level/Select',
+  title: 'Agent/Components low level/Select',
   component: SelectBase,
   argTypes: {
     onChange: { action: 'onChange' },

--- a/packages/Form/Input/select/src/SelectInput.stories.tsx
+++ b/packages/Form/Input/select/src/SelectInput.stories.tsx
@@ -5,7 +5,7 @@ import SelectInput from './SelectInput';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Select',
+  title: 'Agent/Form elements/Select',
   component: SelectInput,
   parameters: {
     readme: {

--- a/packages/Form/Input/slider/src/Slider.stories.tsx
+++ b/packages/Form/Input/slider/src/Slider.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react';
 import Slider from './Slider';
 
 export default {
-  title: 'Components/Slider',
+  title: 'Agent/Components/Slider',
   component: Slider,
 } as Meta;
 

--- a/packages/Form/Input/switch/src/Switch.stories.tsx
+++ b/packages/Form/Input/switch/src/Switch.stories.tsx
@@ -7,7 +7,7 @@ import readme from '../README.md';
 import SwitchItem from './SwitchItem';
 
 export default {
-  title: 'Form elements/Radio switch',
+  title: 'Agent/Form elements/Radio switch',
   component: Switch,
   parameters: {
     readme: {

--- a/packages/Form/Input/text/src/Text.stories.tsx
+++ b/packages/Form/Input/text/src/Text.stories.tsx
@@ -4,7 +4,7 @@ import Text from './Text';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Text',
+  title: 'Agent/Form elements/Text',
   component: Text,
   parameters: {
     readme: {

--- a/packages/Form/Input/text/src/TextInput.stories.tsx
+++ b/packages/Form/Input/text/src/TextInput.stories.tsx
@@ -6,7 +6,7 @@ import TextInput from './TextInput';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Text',
+  title: 'Agent/Form elements/Text',
   component: TextInput,
   parameters: {
     readme: {

--- a/packages/Form/Input/textarea/src/Textarea.stories.tsx
+++ b/packages/Form/Input/textarea/src/Textarea.stories.tsx
@@ -5,7 +5,7 @@ import Readme from '../README.md';
 import './textarea.scss';
 
 export default {
-  title: 'Form elements/Textarea',
+  title: 'Agent/Form elements/Textarea',
   component: Textarea,
   parameters: {
     readme: {

--- a/packages/Form/Input/textarea/src/TextareaInput.stories.tsx
+++ b/packages/Form/Input/textarea/src/TextareaInput.stories.tsx
@@ -5,7 +5,7 @@ import TextareaInput from './TextareaInput';
 import Readme from '../README.md';
 
 export default {
-  title: 'Form elements/Textarea',
+  title: 'Agent/Form elements/Textarea',
   component: TextareaInput,
   parameters: {
     readme: {

--- a/packages/Form/steps/src/Steps.stories.tsx
+++ b/packages/Form/steps/src/Steps.stories.tsx
@@ -7,7 +7,7 @@ import StepBase from './StepBase';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Steps',
+  title: 'Agent/Form elements/Steps',
   component: Steps,
   parameters: {
     readme: {

--- a/packages/Form/summary/src/Summary.stories.tsx
+++ b/packages/Form/summary/src/Summary.stories.tsx
@@ -4,7 +4,7 @@ import Summary from './Summary';
 import readme from '../README.md';
 
 export default {
-  title: 'Form elements/Summary',
+  title: 'Agent/Form elements/Summary',
   component: Summary,
   parameters: {
     readme: {

--- a/packages/Layout/footer-client/src/FooterClient.stories.tsx
+++ b/packages/Layout/footer-client/src/FooterClient.stories.tsx
@@ -9,7 +9,7 @@ import LanguageSelection from './LanguageSelection';
 import readme from '../README.md';
 
 export default {
-  title: 'Structure/Footer client',
+  title: 'Client/Structure/Footer client',
   component: FooterClient,
   parameters: {
     readme: {

--- a/packages/Layout/footer/src/Footer.stories.tsx
+++ b/packages/Layout/footer/src/Footer.stories.tsx
@@ -7,7 +7,7 @@ import readme from '../README.md';
 import './footer.scss';
 
 export default {
-  title: 'Structure/Footer',
+  title: 'Agent/Structure/Footer',
   component: Footer,
   parameters: {
     readme: {

--- a/packages/Layout/header/src/Header/Header.stories.tsx
+++ b/packages/Layout/header/src/Header/Header.stories.tsx
@@ -6,7 +6,7 @@ import { Infos } from '../Infos';
 import readme from '../../README.md';
 
 export default {
-  title: 'Structure/Header',
+  title: 'Agent/Structure/Header',
   component: Header,
   parameters: {
     readme: {

--- a/packages/Layout/header/src/Infos/Infos.stories.tsx
+++ b/packages/Layout/header/src/Infos/Infos.stories.tsx
@@ -4,7 +4,7 @@ import Infos from './Infos';
 import readme from '../../README.md';
 
 export default {
-  title: 'Structure/Header/Infos',
+  title: 'Agent/Structure/Header/Infos',
   component: Infos,
   parameters: {
     readme: {

--- a/packages/Layout/header/src/MenuTitleWrapper.stories.tsx
+++ b/packages/Layout/header/src/MenuTitleWrapper.stories.tsx
@@ -4,7 +4,7 @@ import { NavBar, NavBarItem } from './NavBar';
 import { Title } from './Title';
 
 export default {
-  title: 'Structure/Header/MenuTitleWrapper',
+  title: 'Agent/Structure/Header/MenuTitleWrapper',
   component: NavBar,
   parameters: {
     viewport: {

--- a/packages/Layout/header/src/Name/Name.stories.tsx
+++ b/packages/Layout/header/src/Name/Name.stories.tsx
@@ -4,7 +4,7 @@ import Name from './Name';
 import readme from '../../README.md';
 
 export default {
-  title: 'Structure/Header/Name',
+  title: 'Agent/Structure/Header/Name',
   component: Name,
   parameters: {
     readme: {

--- a/packages/Layout/header/src/NavBar/NavBar.stories.tsx
+++ b/packages/Layout/header/src/NavBar/NavBar.stories.tsx
@@ -6,7 +6,7 @@ import NavBarItem from './NavBarItem';
 import readme from './NavBar.md';
 
 export default {
-  title: 'Structure/Navigation',
+  title: 'Agent/Structure/Navigation',
   component: NavBar,
   args: {
     isVisible: true,

--- a/packages/Layout/header/src/NavBar/NavBarItem.stories.tsx
+++ b/packages/Layout/header/src/NavBar/NavBarItem.stories.tsx
@@ -5,7 +5,7 @@ import NavBarItem from './NavBarItem';
 import readme from './NavBarItem.md';
 
 export default {
-  title: 'Components low level/Navigation/NavBarItem',
+  title: 'Agent/Components low level/Navigation/NavBarItem',
   component: NavBarItem,
   parameters: {
     readme: {

--- a/packages/Layout/header/src/Title/Title.stories.tsx
+++ b/packages/Layout/header/src/Title/Title.stories.tsx
@@ -6,7 +6,7 @@ import Title from './Title';
 import readme from '../../README.md';
 
 export default {
-  title: 'Structure/Title Bar',
+  title: 'Agent/Structure/Title Bar',
   component: Title,
   parameters: {
     readme: {

--- a/packages/Layout/header/src/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/Layout/header/src/ToggleButton/ToggleButton.stories.tsx
@@ -5,7 +5,7 @@ import ToggleButton from '.';
 import readme from './ToggleButton.md';
 
 export default {
-  title: 'Structure/Header/ToggleButton',
+  title: 'Agent/Structure/Header/ToggleButton',
   component: ToggleButton,
   parameters: {
     readme: {

--- a/packages/Layout/header/src/User/User.stories.tsx
+++ b/packages/Layout/header/src/User/User.stories.tsx
@@ -4,7 +4,7 @@ import User from './User';
 import readme from '../../README.md';
 
 export default {
-  title: 'Structure/Header/User',
+  title: 'Agent/Structure/Header/User',
   component: User,
   parameters: {
     readme: {

--- a/packages/Modal/boolean/src/ModalBoolean.stories.tsx
+++ b/packages/Modal/boolean/src/ModalBoolean.stories.tsx
@@ -4,7 +4,7 @@ import BooleanModal from './ModalBoolean';
 import readme from '../README.md';
 
 export default {
-  title: 'Components high level/Modal/Boolean',
+  title: 'Agent/Components high level/Modal/Boolean',
   component: BooleanModal,
   parameters: {
     readme: {

--- a/packages/Modal/default/src/ModalDefault.stories.tsx
+++ b/packages/Modal/default/src/ModalDefault.stories.tsx
@@ -85,7 +85,7 @@ ModalCoreStrory.args = {
 };
 
 export default {
-  title: 'Components/Modal/Default',
+  title: 'Agent/Components/Modal/Default',
   component: Modal,
   parameters: {
     readme: {

--- a/packages/action/src/Action.stories.tsx
+++ b/packages/action/src/Action.stories.tsx
@@ -6,7 +6,7 @@ import Readme from '../README.md';
 type ActionProps = ComponentProps<typeof Action>;
 
 export default {
-  title: 'Components/Action',
+  title: 'Agent/Components/Action',
   component: Action,
   parameters: {
     readme: {

--- a/packages/action/src/ActionCore.stories.tsx
+++ b/packages/action/src/ActionCore.stories.tsx
@@ -4,7 +4,7 @@ import ActionCore from './ActionCore';
 import Readme from '../README.md';
 
 export default {
-  title: 'Components low level/Action',
+  title: 'Agent/Components low level/Action',
   component: ActionCore,
   parameters: {
     readme: {

--- a/packages/alert/src/Alert.stories.tsx
+++ b/packages/alert/src/Alert.stories.tsx
@@ -7,7 +7,7 @@ import readme from '../README.md';
 const MODIFIERS = ['success', 'info', 'danger', 'error'];
 
 const story = {
-  title: 'Components/Alert',
+  title: 'Agent/Components/Alert',
   component: Alert,
   parameters: {
     readme: {

--- a/packages/alert/src/AlertCore.stories.tsx
+++ b/packages/alert/src/AlertCore.stories.tsx
@@ -7,7 +7,7 @@ import readme from '../README.md';
 const MODIFIERS = ['success', 'info', 'danger', 'error'];
 
 const story = {
-  title: 'Components low level/Alert/AlertCore',
+  title: 'Agent/Components low level/Alert/AlertCore',
   component: AlertCore,
   parameters: {
     readme: {

--- a/packages/alert/src/AlertWithType.stories.tsx
+++ b/packages/alert/src/AlertWithType.stories.tsx
@@ -7,7 +7,7 @@ import readme from '../README.md';
 const MODIFIERS = ['success', 'info', 'danger', 'error'];
 
 const story = {
-  title: 'Components low level/Alert/AlertWithType',
+  title: 'Agent/Components low level/Alert/AlertWithType',
   component: AlertWithType,
   parameters: {
     readme: {

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -40,6 +40,7 @@
     "@axa-fr/react-toolkit-form-steps": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-form-summary": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-help": "2.0.1-alpha.0",
+    "@axa-fr/react-toolkit-header-client-app": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-helpinfo": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-highlight": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-icon": "2.0.1-alpha.0",

--- a/packages/all/src/bootstrap/af-components-client.template.scss
+++ b/packages/all/src/bootstrap/af-components-client.template.scss
@@ -1,0 +1,3 @@
+@import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
+
+<%= axaComponents %>

--- a/packages/all/src/header-client-app.ts
+++ b/packages/all/src/header-client-app.ts
@@ -1,0 +1,1 @@
+export { default as HeaderClientApp } from '@axa-fr/react-toolkit-header-client-app';

--- a/packages/all/src/index.ts
+++ b/packages/all/src/index.ts
@@ -23,6 +23,7 @@ export * from './form-input-text';
 export * from './form-input-textarea';
 export * from './form-steps';
 export * from './form-summary';
+export * from './header-client-app';
 export * from './help';
 export * from './help-info';
 export * from './highlight';

--- a/packages/badge/src/Badge.stories.tsx
+++ b/packages/badge/src/Badge.stories.tsx
@@ -4,7 +4,7 @@ import Badge from './Badge';
 import readme from '../README.md';
 
 export default {
-  title: 'Components/Badge',
+  title: 'Agent/Components/Badge',
   component: Badge,
   parameters: {
     readme: {

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -17,7 +17,7 @@ const MODIFIERS = [
 ];
 
 const story = {
-  title: 'Components/Button',
+  title: 'Agent/Components/Button',
   component: Button,
   parameters: {
     readme: {

--- a/packages/collapse/src/Accordion.stories.tsx
+++ b/packages/collapse/src/Accordion.stories.tsx
@@ -6,7 +6,7 @@ import CollapseCard from './CollapseCard';
 import readme from '../README.md';
 
 export default {
-  title: 'Components/Accordion',
+  title: 'Agent/Components/Accordion',
   component: Accordion,
   parameters: {
     readme: {

--- a/packages/collapse/src/CollapseCard.stories.tsx
+++ b/packages/collapse/src/CollapseCard.stories.tsx
@@ -5,7 +5,7 @@ import CollapseCard from './CollapseCard';
 import readme from '../README.md';
 
 export default {
-  title: 'Components low level/Collapse',
+  title: 'Agent/Components low level/Collapse',
   component: CollapseCard,
   parameters: {
     readme: {

--- a/packages/header-client-app/README.md
+++ b/packages/header-client-app/README.md
@@ -1,0 +1,27 @@
+# `@axa-fr/react-toolkit-header-client-app`
+
+## Default
+
+### Installation
+
+```shell script
+npm i @axa-fr/react-toolkit-header-client-app
+```
+
+### Import
+
+```javascript
+import Title from '@axa-fr/react-toolkit-header-client-app';
+import '@axa-fr/react-toolkit-header-client-app/dist/afc-header-app.css';
+```
+
+### Use
+
+```javascript
+const HeaderApp = () => (
+  <HeaderClientApp rightChildren={<a>Annuler<a>} leftChildren={<a>Retour<a>}  >
+    Sample Title
+  </HeaderClientApp>
+);
+export default HeaderApp;
+```

--- a/packages/header-client-app/package.json
+++ b/packages/header-client-app/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@axa-fr/react-toolkit-header-client-app",
+  "version": "2.0.1-alpha.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "jsnext:main": "src/index.js",
+  "types": "dist/esm/index.d.ts",
+  "private": false,
+  "scripts": {
+    "build": "rimraf ./dist && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+  },
+  "dependencies": {
+    "@axa-fr/react-toolkit-core": "2.0.1-alpha.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxaGuilDEv/react-toolkit.git"
+  }
+}

--- a/packages/header-client-app/src/HeaderClientApp.stories.tsx
+++ b/packages/header-client-app/src/HeaderClientApp.stories.tsx
@@ -1,0 +1,36 @@
+import React, { ComponentPropsWithoutRef } from 'react';
+import { Meta, Story } from '@storybook/react';
+import HeaderClientApp from './HeaderClientApp';
+import Readme from '../README.md';
+
+export default {
+  title: 'Client/Components/Header App',
+  component: HeaderClientApp,
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone6',
+    },
+    readme: {
+      sidebar: Readme,
+    },
+    options: {},
+  },
+} as Meta;
+
+type HeaderClientAppStoryProps = ComponentPropsWithoutRef<
+  typeof HeaderClientApp
+> & {
+  title: string;
+};
+const Template: Story<HeaderClientAppStoryProps> = ({ children, ...args }) => (
+  <HeaderClientApp {...args}>{children}</HeaderClientApp>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  children: 'Sample Title',
+  classModifier: '',
+  className: '',
+  leftChildren: <span className="material-icons">arrow_back</span>,
+  rightChildren: <span className="material-icons">arrow_forward</span>,
+};

--- a/packages/header-client-app/src/HeaderClientApp.tsx
+++ b/packages/header-client-app/src/HeaderClientApp.tsx
@@ -1,0 +1,32 @@
+import React, { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { getComponentClassName } from '@axa-fr/react-toolkit-core';
+
+type HeaderClientAppProps = ComponentPropsWithoutRef<'header'> & {
+  classModifier?: string;
+  leftChildren?: ReactNode;
+  rightChildren?: ReactNode;
+};
+
+const HeaderClientApp = ({
+  className,
+  classModifier,
+  children,
+  leftChildren,
+  rightChildren,
+  ...otherProps
+}: HeaderClientAppProps) => {
+  const componentClassName = getComponentClassName(
+    className,
+    classModifier,
+    'afc-header-app'
+  );
+  return (
+    <header className={componentClassName} {...otherProps}>
+      {leftChildren}
+      {children}
+      {rightChildren}
+    </header>
+  );
+};
+
+export default HeaderClientApp;

--- a/packages/header-client-app/src/__tests__/HeaderClientApp.spec.tsx
+++ b/packages/header-client-app/src/__tests__/HeaderClientApp.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HeaderClientApp from '../HeaderClientApp';
+
+describe('HeaderClientApp', () => {
+  it('should render children', () => {
+    render(
+      <HeaderClientApp
+        leftChildren={<p>gauche</p>}
+        rightChildren={<p>droite</p>}>
+        A title
+      </HeaderClientApp>
+    );
+    expect(screen.getByText(/A title/)).toBeInTheDocument();
+    expect(screen.getByText(/gauche/)).toBeInTheDocument();
+    expect(screen.getByText(/droite/)).toBeInTheDocument();
+  });
+
+  it('should have default class', () => {
+    render(<HeaderClientApp>A title</HeaderClientApp>);
+    expect(screen.getByText(/A title/)).toHaveClass('afc-header-app', {
+      exact: true,
+    });
+  });
+
+  it('should have custom class', () => {
+    render(<HeaderClientApp className="custom-class">A title</HeaderClientApp>);
+    expect(screen.getByText(/A title/)).toHaveClass('custom-class', {
+      exact: true,
+    });
+  });
+
+  it('should have custom class with modifier', () => {
+    render(
+      <HeaderClientApp className="custom-class" classModifier="modifier">
+        A title
+      </HeaderClientApp>
+    );
+
+    expect(screen.getByText(/A title/)).toHaveClass(
+      'custom-class custom-class--modifier',
+      {
+        exact: true,
+      }
+    );
+  });
+
+  it('should not have classModifier attribute', () => {
+    render(
+      <HeaderClientApp className="custom-class" classModifier="modifier">
+        A title
+      </HeaderClientApp>
+    );
+
+    expect(screen.getByText(/A title/)).not.toHaveAttribute('classModifier');
+  });
+});

--- a/packages/header-client-app/src/header-client-app.scss
+++ b/packages/header-client-app/src/header-client-app.scss
@@ -1,0 +1,19 @@
+@import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
+
+.afc-header-app {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  background: $color-axa;
+  color: $color-texte;
+  font-size: rem(14px);
+  line-height: rem(20px);
+  padding: rem(16px);
+  color: $color-white;
+  text-align: center;
+  .material-icons {
+    font-size: rem(22px);
+  }
+  > * {
+    color: $color-white;
+  }
+}

--- a/packages/header-client-app/src/index.ts
+++ b/packages/header-client-app/src/index.ts
@@ -1,0 +1,3 @@
+import HeaderClientApp from './HeaderClientApp';
+
+export default HeaderClientApp;

--- a/packages/header-client-app/tsconfig-cjs.json
+++ b/packages/header-client-app/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig-cjs.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs"
+  },
+  "include": ["./src/index.ts"]
+}

--- a/packages/header-client-app/tsconfig.json
+++ b/packages/header-client-app/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm"
+  },
+  "include": ["./src/index.ts"]
+}

--- a/packages/help/src/Help.stories.tsx
+++ b/packages/help/src/Help.stories.tsx
@@ -6,7 +6,7 @@ import readme from '../README.md';
 import './help-custom.scss';
 
 export default {
-  title: 'Components high level/Help',
+  title: 'Agent/Components high level/Help',
   component: Help,
   parameters: {
     readme: {

--- a/packages/helpinfo/src/HelpInfo.stories.tsx
+++ b/packages/helpinfo/src/HelpInfo.stories.tsx
@@ -8,7 +8,7 @@ import readme from '../README.md';
 import './help-info.scss';
 
 export default {
-  title: 'Components high level/HelpInfo',
+  title: 'Agent/Components high level/HelpInfo',
   component: HelpInfo,
   parameters: {
     readme: {

--- a/packages/loader/src/Loader.stories.tsx
+++ b/packages/loader/src/Loader.stories.tsx
@@ -5,7 +5,7 @@ import LoaderModes from './LoaderModes';
 import readme from '../README.md';
 
 export default {
-  title: 'Components/Loader',
+  title: 'Agent/Components/Loader',
   component: Loader,
   parameters: {
     readme: {

--- a/packages/popover/src/Popover.stories.tsx
+++ b/packages/popover/src/Popover.stories.tsx
@@ -6,7 +6,7 @@ import PopoverModes from './PopoverModes';
 import Readme from '../README.md';
 
 export default {
-  title: 'Components/Popover',
+  title: 'Agent/Components/Popover',
   component: Popover,
   parameters: {
     readme: {

--- a/packages/popover/src/PopoverBase.stories.tsx
+++ b/packages/popover/src/PopoverBase.stories.tsx
@@ -6,7 +6,7 @@ import Readme from '../README.md';
 import './help-custom.scss';
 
 export default {
-  title: 'Components low level/Popover',
+  title: 'Agent/Components low level/Popover',
   component: PopoverBase,
   parameters: {
     readme: {

--- a/packages/restitution/src/Restitution.stories.tsx
+++ b/packages/restitution/src/Restitution.stories.tsx
@@ -16,7 +16,7 @@ const withPreventDefaultClick = (next: any) => (e: any) => {
 };
 
 export default {
-  title: 'Components/Restitution',
+  title: 'Agent/Components/Restitution',
   component: Restitution,
   parameters: {
     readme: {

--- a/packages/table/src/Items/Items.stories.tsx
+++ b/packages/table/src/Items/Items.stories.tsx
@@ -4,7 +4,7 @@ import Items, { Props } from './Items';
 import readme from './README.md';
 
 export default {
-  title: 'Components/Table/Items',
+  title: 'Agent/Components/Table/Items',
   component: Items,
   parameters: {
     readme: {

--- a/packages/table/src/Pager/Pager.stories.tsx
+++ b/packages/table/src/Pager/Pager.stories.tsx
@@ -5,7 +5,7 @@ import Modes from './Modes';
 import Readme from './README.md';
 
 export default {
-  title: 'Components/Table/Pager',
+  title: 'Agent/Components/Table/Pager',
   component: Pager,
   parameters: {
     readme: {

--- a/packages/table/src/Paging/Paging.stories.tsx
+++ b/packages/table/src/Paging/Paging.stories.tsx
@@ -5,7 +5,7 @@ import Modes from '../Pager/Modes';
 import Readme from './README.md';
 
 export default {
-  title: 'Components/Table/Paging',
+  title: 'Agent/Components/Table/Paging',
   component: Paging,
   parameters: {
     readme: {

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -23,7 +23,7 @@ const modifiers = [
 ];
 
 export default {
-  title: 'Components/Table',
+  title: 'Agent/Components/Table',
   component: Table,
   parameters: {
     readme: {

--- a/packages/tabs/src/Tabs.stories.tsx
+++ b/packages/tabs/src/Tabs.stories.tsx
@@ -6,7 +6,7 @@ import Readme from '../README.md';
 import { TabsCoreProps } from './TabsCore';
 
 export default {
-  title: 'Components/Tabs',
+  title: 'Agent/Components/Tabs',
   component: Tabs,
   parameters: {
     readme: {

--- a/packages/title/src/Title.stories.tsx
+++ b/packages/title/src/Title.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { ComponentPropsWithoutRef } from 'react';
 import { Meta, Story } from '@storybook/react';
-import Title, { TitleProps } from './Title';
+import Title from './Title';
 import Readme from '../README.md';
 
 export default {
-  title: 'Components/Title',
+  title: 'Agent/Components/Title',
   component: Title,
   parameters: {
     readme: {
@@ -14,7 +14,7 @@ export default {
   },
 } as Meta;
 
-type TitleStoryProps = TitleProps & {
+type TitleStoryProps = ComponentPropsWithoutRef<typeof Title> & {
   title: string;
 };
 const Template: Story<TitleStoryProps> = ({ title, ...args }) => (

--- a/packages/title/src/TitleClient.stories.tsx
+++ b/packages/title/src/TitleClient.stories.tsx
@@ -1,0 +1,32 @@
+import React, { ComponentPropsWithoutRef } from 'react';
+import { Meta, Story } from '@storybook/react';
+import Title from './Title';
+import Readme from '../README.md';
+
+export default {
+  title: 'Client/Components/Title',
+  component: Title,
+  parameters: {
+    viewport: {
+      defaultViewport: 'iphone6',
+    },
+    readme: {
+      sidebar: Readme,
+    },
+    options: {},
+  },
+} as Meta;
+
+type TitleStoryProps = ComponentPropsWithoutRef<typeof Title> & {
+  title: string;
+};
+const Template: Story<TitleStoryProps> = ({ title, ...args }) => (
+  <Title {...args}>{title} </Title>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  title: 'Sample Title',
+  classModifier: '',
+  className: 'afc-title',
+};

--- a/packages/title/src/title-client.scss
+++ b/packages/title/src/title-client.scss
@@ -1,0 +1,20 @@
+@import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
+
+.afc-title {
+  position: relative;
+  font-weight: 700;
+  color: $color-texte;
+  font-size: rem(28px);
+  line-height: rem(34px);
+  padding-bottom: rem(24px);
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 1px;
+    width: 40px;
+    background-color: $color-dusty-gray;
+  }
+}

--- a/scripts/style.js
+++ b/scripts/style.js
@@ -82,9 +82,14 @@ const prepareStylePackages = (packagesScssfiles) => {
     const outputPath = `${path
       .dirname(scssFile)
       .replace(`/${src}`, `/${dist}`)}`;
-    const outputName = `/af-${path
-      .basename(scssFile)
-      .replace(`.scss`, '.css')}`;
+
+    let outputName = '';
+
+    if (scssFile.includes('afc-')) {
+      outputName = `/${path.basename(scssFile).replace(`.scss`, '.css')}`;
+    } else {
+      outputName = `/af-${path.basename(scssFile).replace(`.scss`, '.css')}`;
+    }
 
     if (!fs.existsSync(outputPath)) {
       fs.mkdirSync(outputPath, { recursive: true });
@@ -151,15 +156,18 @@ const setFileImport = (filePath) => {
 /**
  * generation package /all Scss
  */
-const generateAfToolkitCore = (packagesScssfiles) => {
-  logStart('af-toolkit-core', true);
+const generateAll = (packagesScssfiles, name = 'af-components') => {
+  logStart('generate All', true);
   const imports = packagesScssfiles
     .map((scssFile) => setFileImport(scssFile))
     .join('\n');
 
-  generateContentScss(imports, 'af-toolkit-core');
-  generateContentScss(imports, 'af-components');
-  logFinished('af-toolkit-core', true);
+  if (name === 'af-components') {
+    generateContentScss(imports, 'af-toolkit-core');
+  }
+  generateContentScss(imports, name);
+
+  logFinished('generate All', true);
 };
 
 const generateContentScss = (imports, name) => {
@@ -292,7 +300,17 @@ try {
   const cleanedScssFiles = cleanPathScssPackagesFiles(scssFiles);
   const packagesScssfiles = getScssPackagesFiles(cleanedScssFiles);
   prepareStylePackages(packagesScssfiles);
-  generateAfToolkitCore(packagesScssfiles);
+
+  const clientFiles = packagesScssfiles.filter((file) =>
+    file.includes('-client')
+  );
+  const agentFiles = packagesScssfiles.filter(
+    (file) => !file.includes('-client')
+  );
+
+  generateAll(agentFiles);
+  generateAll(clientFiles, 'af-components-client');
+
   copyCoreFiles();
   copyBootstrapFiles();
 } catch (err) {


### PR DESCRIPTION
## Avoir des composants pour la partie client AXA

- réorganisation du storybook avec 2 grandes parties AGENT/CLIENT
- dans le cas, où le composant existe déjà côté agent
   - on ajoute une feuille de style dédiée (Ex : composant Title) 
   - on créé une storie dédiée qu'on positionne dans Client
- sinon on créé un nouveau composant (ex : composant HeaderClientApp)

J'ai proposé des nomenclatures de nommage comme par exemple .afc-nomducomposant pour les classes du style client

Côté all, on génère toujours le af-components et le af-toolkit-core mais en plus on génère af-components-client qui regroupe tous les styles client.

Un petit screen : 

![image](https://user-images.githubusercontent.com/16844565/224367107-e210d4be-089f-457c-8371-c3b3da9066dd.png)


### Person(s) for reviewing proposed changes

@arnaudforaison @MartinWeb @johankorger 

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
