### PR TITLE
fix: ajout 'classModifier' désactivé + style au bouton cercle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35526,6 +35526,7 @@
       }
     },
     "packages/helpinfo": {
+      "name": "@axa-fr/react-toolkit-helpinfo",
       "version": "2.0.1-alpha.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -108,6 +108,7 @@ ButtonWithRightIconStory.args = {
 export const ButtonCircleStory: Story<ButtonProps> = Template.bind({});
 ButtonCircleStory.storyName = 'Button circle';
 ButtonCircleStory.args = {
+  disabled: false,
   className: 'af-btn--circle',
   children: <i className="glyphicon glyphicon-floppy-disk" />,
 };

--- a/packages/button/src/button.scss
+++ b/packages/button/src/button.scss
@@ -197,6 +197,21 @@ $active-sort-table-th: $color-table-sorting !default;
       transform: translate(-50%, -50%);
       width: 17px;
     }
+
+    &--disabled {
+      cursor: not-allowed;
+      background-color: $color-mercury;
+      box-shadow: inset 0 -3px $color-silver;
+      color: $color-btn-disabled;
+
+      &:hover,
+      &:focus {
+        background-color: $color-mercury;
+        box-shadow: inset 0 -3px $color-silver;
+        color: $color-btn-disabled;
+        border-color: transparent;
+      }
+    }
   }
 
   &--circle-small {


### PR DESCRIPTION
### Reference to the issue
https://github.com/AxaFrance/react-toolkit/issues/1026

### Description of the issue

ajouter un bouton cercle désactivé 

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
