### PR TITLE
fix(date): call onChange with a null value when the date input is cle…

### DIFF
--- a/packages/Form/Input/date/src/Date.tsx
+++ b/packages/Form/Input/date/src/Date.tsx
@@ -9,7 +9,7 @@ type Props = Omit<ComponentPropsWithRef<'input'>, 'value'> & {
   value?: Date;
 };
 
-const Date = forwardRef<HTMLInputElement, Props>(
+const CustomDate = forwardRef<HTMLInputElement, Props>(
   ({ className, classModifier, value, ...otherProps }, ref) => {
     const componentClassName = getComponentClassName(
       className,
@@ -46,7 +46,6 @@ const handlers = {
     (e: ChangeEvent<HTMLInputElement>) => {
       const newValue = e.currentTarget.valueAsDate;
       onChange &&
-        newValue &&
         onChange({
           value: newValue,
           name,
@@ -55,4 +54,4 @@ const handlers = {
     },
 };
 
-export default withInput(handlers)(Date);
+export default withInput(handlers)(CustomDate);


### PR DESCRIPTION
…ared

## Related issue 

### Reference to the issue

close #1002 

### Description of the issue

The date input call the onChange prop even when the "clear" native behavior is clicked. The component will send a null value. 

### Person(s) for reviewing proposed changes

@lilian-delouvy 

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
