### PR TITLE
test(NumberInput): type a minus sign in a NumberInput

### DIFF
--- a/packages/Form/Input/number/src/NumberInput.stories.tsx
+++ b/packages/Form/Input/number/src/NumberInput.stories.tsx
@@ -30,7 +30,7 @@ const Template: Story<
         value={value}
         onChange={(e) => {
           action('onChange')(e);
-          setValue(e.value);
+          setValue(!isNaN(e.value) ? e.value : null);
         }}>
         <Help>tooltip avec du text</Help>
       </NumberInput>


### PR DESCRIPTION
Impossible to type a minus sign in a NumberInput 
#999

[`link to related issue`](https://github.com/AxaFrance/react-toolkit/issues/999)

`On a NumberInput, when you can type a minus sign the first time, but if you clear the input and you try again to type the minus sign, nothing happen and the value prop contains NaN,it was a bug that affected only the Storybook, the bug is not present in the component`

@johnmeunier @arnaudforaison 

