### PR TITLE
fix: remove require of helpinfo css to stop causing crash from vite/vitest apps

### DIFF
--- a/packages/helpinfo/src/HelpInfo.stories.tsx
+++ b/packages/helpinfo/src/HelpInfo.stories.tsx
@@ -5,7 +5,6 @@ import Button from '@axa-fr/react-toolkit-button';
 import Badge from '@axa-fr/react-toolkit-badge';
 import HelpInfo from './HelpInfo';
 import readme from '../README.md';
-import './help-info.scss';
 
 export default {
   title: 'Components high level/HelpInfo',

--- a/packages/helpinfo/src/HelpInfo.tsx
+++ b/packages/helpinfo/src/HelpInfo.tsx
@@ -1,6 +1,5 @@
 import React, { ComponentPropsWithoutRef, ReactNode } from 'react';
 import Popover, { PopoverPlacements } from '@axa-fr/react-toolkit-popover';
-import './help-info.scss';
 
 export type Props = ComponentPropsWithoutRef<typeof Popover>;
 


### PR DESCRIPTION
## Related issue
[1074](https://github.com/AxaFrance/react-toolkit/issues/1074)