### PR TITLE
feat(accessibility): add tabindex for select current tab with keyboard

### DIFF
--- a/packages/collapse/src/Header.tsx
+++ b/packages/collapse/src/Header.tsx
@@ -52,7 +52,7 @@ const Header = ({
   };
 
   const onKeyToggle = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter') {
       e.preventDefault();
       onToggle &&
         onToggle({
@@ -75,15 +75,19 @@ const Header = ({
   );
 
   return (
-    <div className={componentClassName} role="tab" id={id}>
+    <div
+      className={componentClassName}
+      tabIndex={0}
+      role="tab"
+      id={id}
+      onKeyDown={onKeyToggle}>
       <a
         className="af-accordion__item-toggle"
         data-toggle="isOpen"
         href={href}
         aria-expanded={isOpen}
         aria-controls={ariaControls}
-        onClick={onToggleEvent}
-        onKeyDown={onKeyToggle}>
+        onClick={onToggleEvent}>
         <h3 className="af-accordion__item-title">
           <span className={chevronClassName} />
           {children}

--- a/packages/collapse/src/__tests__/__snapshots__/Accordion.spec.tsx.snap
+++ b/packages/collapse/src/__tests__/__snapshots__/Accordion.spec.tsx.snap
@@ -14,6 +14,7 @@ exports[`Accordion renders Accordion correctly 1`] = `
         class="af-accordion__item-header"
         id="one"
         role="tab"
+        tabindex="0"
       >
         <a
           aria-controls="onebody"
@@ -53,6 +54,7 @@ exports[`Accordion renders Accordion correctly 1`] = `
         class="af-accordion__item-header"
         id="two"
         role="tab"
+        tabindex="0"
       >
         <a
           aria-controls="twobody"
@@ -92,6 +94,7 @@ exports[`Accordion renders Accordion correctly 1`] = `
         class="af-accordion__item-header"
         id="three"
         role="tab"
+        tabindex="0"
       >
         <a
           aria-controls="threebody"

--- a/packages/collapse/src/__tests__/__snapshots__/CollapseCard.spec.tsx.snap
+++ b/packages/collapse/src/__tests__/__snapshots__/CollapseCard.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`CollapseCard renders CollapseCard correctly 1`] = `
       class="af-accordion__item-header"
       id="collapse1"
       role="tab"
+      tabindex="0"
     >
       <a
         aria-controls="collapse1body"

--- a/packages/collapse/src/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/collapse/src/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`Accordion.Header renders Accordion.Header correctly 1`] = `
   <div
     class="af-accordion__item-header"
     role="tab"
+    tabindex="0"
   >
     <a
       aria-expanded="false"


### PR DESCRIPTION
feat(accessibility): add tabindex for select current tab with keyboard

## Related issue
https://github.com/AxaFrance/react-toolkit/issues/1081

### Description of the issue

![demo](https://github.com/AxaFrance/react-toolkit/assets/113119445/916ac752-acfb-4c98-a173-b6493dd86d8a)

On the gif, I use only keyboard for collapse the accordion

