### PR TITLE
docs: modify README for components's imports (don't use component folder inside toolkit-all)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -25,6 +25,22 @@ import { getComponentClassName } from '@axa-fr/react-toolkit-core';
 className={getComponentClassName(...)}
 ```
 
+## Imports
+
+With the tree shaking and the separation between CommonJS and ECMAScript files, you should'n import the components from the component folder of the react-toolkit-all package.
+
+Before :
+
+```javascript
+import { Alert } from '@axa-fr/react-toolkit-all/component/alert';
+```
+
+After :
+
+```javascript
+import { Alert } from '@axa-fr/react-toolkit-all';
+```
+
 # From version 1.x to 2.0.x
 
 ## Date Input

--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ npm install @axa-fr/react-toolkit-all --save
 
 ```javascript
 import React from 'react';
-
-// Load only the component alert (smaller bundle size)
-import { Alert } from '@axa-fr/react-toolkit-all/component/alert';
-
-// Load all the toolkit (bigger bundle size)
 import { Alert } from '@axa-fr/react-toolkit-all';
 
 import '@axa-fr/react-toolkit-all/dist/style/af-toolkit-core.scss';


### PR DESCRIPTION
Remove use of component folder inside toolkit-all in documentation