### PR TITLE
fix(a11y): remove double aria-label

### DIFF
--- a/packages/Form/Input/checkbox/src/__tests__/__snapshots__/CheckboxInput.spec.tsx.snap
+++ b/packages/Form/Input/checkbox/src/__tests__/__snapshots__/CheckboxInput.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`<DateInput> renders DateInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Image *"
         class="af-form__group-label"
         for="id"
       >

--- a/packages/Form/Input/choice/src/__tests__/__snapshots__/Choice.spec.tsx.snap
+++ b/packages/Form/Input/choice/src/__tests__/__snapshots__/Choice.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`<ChoiceInput> renders ChoiceInput correctly when passing options with I
       class="col-md-2"
     >
       <label
-        aria-label="Some label"
         class="af-form__group-label"
         for="xxx_Yes"
       >
@@ -75,7 +74,6 @@ exports[`<ChoiceInput> renders ChoiceInput correctly when passing options withou
       class="col-md-2"
     >
       <label
-        aria-label="Some label"
         class="af-form__group-label"
         for="1"
       >
@@ -141,7 +139,6 @@ exports[`<ChoiceInput> renders ChoiceInput correctly with default options 1`] = 
       class="col-md-2"
     >
       <label
-        aria-label="Some label"
         class="af-form__group-label"
         for="oui"
       >
@@ -207,7 +204,6 @@ exports[`<ChoiceInput> renders ChoiceInput correctly with required 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Some label"
         class="af-form__group-label"
         for="oui"
       >

--- a/packages/Form/Input/file/src/__tests__/__snapshots__/FileInput.spec.tsx.snap
+++ b/packages/Form/Input/file/src/__tests__/__snapshots__/FileInput.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`<FileInput> renders FileInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="File *"
         class="af-form__group-label"
         for="id"
       >

--- a/packages/Form/Input/number/src/__tests__/__snapshots__/NumberInput.spec.tsx.snap
+++ b/packages/Form/Input/number/src/__tests__/__snapshots__/NumberInput.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`<NumberInput> renders NumberInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Image *"
         class="af-form__group-label"
         for="iddateinput"
       >

--- a/packages/Form/Input/radio/src/__tests__/__snapshots__/RadioInput.spec.tsx.snap
+++ b/packages/Form/Input/radio/src/__tests__/__snapshots__/RadioInput.spec.tsx.snap
@@ -11,7 +11,6 @@ exports[`<RadioInput /> should have correct html rendered 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="test"
         class="af-form__group-label"
       >
         test

--- a/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelectInput.spec.tsx.snap
+++ b/packages/Form/Input/select-multi/src/__tests__/__snapshots__/MultiSelectInput.spec.tsx.snap
@@ -562,7 +562,6 @@ exports[`renders MultiSelectInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Place type *"
         class="af-form__group-label"
         for="multiselectid"
       >

--- a/packages/Form/Input/select/src/__tests__/__snapshots__/Select.spec.tsx.snap
+++ b/packages/Form/Input/select/src/__tests__/__snapshots__/Select.spec.tsx.snap
@@ -155,7 +155,6 @@ exports[`renders SelectInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="label"
         class="af-form__group-label"
         for="muid"
       >
@@ -222,7 +221,6 @@ exports[`renders SelectInput correctly with classModier 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="label"
         class="af-form__group-label"
         for="muid"
       >

--- a/packages/Form/Input/slider/src/__tests__/__snapshots__/SliderInput.spec.tsx.snap
+++ b/packages/Form/Input/slider/src/__tests__/__snapshots__/SliderInput.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`<SliderInput> renders SliderInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="File *"
         class="af-form__group-label"
         for="id"
       >

--- a/packages/Form/Input/switch/src/__tests__/__snapshots__/SwitchInput.spec.tsx.snap
+++ b/packages/Form/Input/switch/src/__tests__/__snapshots__/SwitchInput.spec.tsx.snap
@@ -11,7 +11,6 @@ exports[`<SwitchInput> renders SwitchInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Image *"
         class="af-form__group-label"
       >
         Image *

--- a/packages/Form/Input/text/src/__tests__/__snapshots__/TextInput.spec.tsx.snap
+++ b/packages/Form/Input/text/src/__tests__/__snapshots__/TextInput.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`TextInput renders TextInput correctly with child 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Image *"
         class="af-form__group-label"
         for="iddateinput"
       >
@@ -49,7 +48,6 @@ exports[`TextInput renders TextInput correctly with classModifier 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Image *"
         class="af-form__group-label"
         for="iddateinput"
       >
@@ -86,7 +84,6 @@ exports[`TextInput renders TextInput correctly with error message 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Image *"
         class="af-form__group-label"
         for="iddateinput"
       >

--- a/packages/Form/Input/textarea/src/__tests__/__snapshots__/TextareaInput.spec.tsx.snap
+++ b/packages/Form/Input/textarea/src/__tests__/__snapshots__/TextareaInput.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`renders TextareaInput correctly 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="Image *"
         class="af-form__group-label"
         for="iddateinput"
       >

--- a/packages/Form/core/src/Field.tsx
+++ b/packages/Form/core/src/Field.tsx
@@ -54,7 +54,6 @@ const Field = ({
       <div className={classNameContainerLabel}>
         <label
           className="af-form__group-label"
-          aria-label={label.toString()}
           htmlFor={isLabelContainerLinkedToInput ? id : null}>
           {label}
         </label>

--- a/packages/Form/core/src/__tests__/__snapshots__/Field.spec.tsx.snap
+++ b/packages/Form/core/src/__tests__/__snapshots__/Field.spec.tsx.snap
@@ -9,7 +9,6 @@ exports[`<Field> Render <Field/> when have children HelpMessage 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="my label"
         class="af-form__group-label"
         for=""
       >
@@ -38,7 +37,6 @@ exports[`<Field> Render <Field/> when have children HelpMessage and have message
       class="col-md-2"
     >
       <label
-        aria-label="my label"
         class="af-form__group-label"
         for=""
       >
@@ -74,7 +72,6 @@ exports[`<Field> Render <Field/> when have children complete example with error 
       class="col-md-2"
     >
       <label
-        aria-label="my label"
         class="af-form__group-label"
         for=""
       >
@@ -120,7 +117,6 @@ exports[`<Field> Render <Field/> when have children complete example without err
       class="col-md-2"
     >
       <label
-        aria-label="my label"
         class="af-form__group-label"
         for=""
       >
@@ -158,7 +154,6 @@ exports[`<Field> Render <Field/> when have message and forceDisplayMessage equal
       class="col-md-2"
     >
       <label
-        aria-label="my label"
         class="af-form__group-label"
         for=""
       >
@@ -196,7 +191,6 @@ exports[`<Field> Render <Field/> when is visible 1`] = `
       class="col-md-2"
     >
       <label
-        aria-label="my label"
         class="af-form__group-label"
         for=""
       >
@@ -221,7 +215,6 @@ exports[`<Field> Render <Field/> with roleContainer and ariaLabelContainer 1`] =
       class="col-md-2"
     >
       <label
-        aria-label="my label"
         class="af-form__group-label"
         for=""
       >


### PR DESCRIPTION
## Related issue

https://github.com/AxaFrance/react-toolkit/issues/1092
https://github.com/AxaFrance/react-toolkit/issues/1093

### Description of the issue

remove redundant aria-label from <label> 

![image](https://github.com/AxaFrance/react-toolkit/assets/20930506/bd36e547-857c-4964-af3d-ea69fb20a93c)


### Person(s) for reviewing proposed changes

@arnaudforaison @samuel-gomez @JLou @MartinWeb 

