### PR TITLE
fix(collapse): stop to regenerate id at each rerender

### DIFF
--- a/packages/collapse/src/CollapseCard.tsx
+++ b/packages/collapse/src/CollapseCard.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-
 import {
   Constants,
   getComponentClassName,
-  useId,
+  useId as getId,
 } from '@axa-fr/react-toolkit-core';
+import React, { useMemo } from 'react';
 import Body, { BodyProps } from './Body';
 import Header, { HeaderProps, HeaderToggleElement } from './Header';
 
@@ -32,7 +31,7 @@ const CollapseCard = ({
   index,
   onToggle,
 }: CollapseProps) => {
-  const headerId = useId(id);
+  const headerId = useMemo(() => getId(id), [id]);
   const [open, setOpen] = React.useState(isOpen);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Related issue

https://github.com/AxaFrance/react-toolkit/issues/1058

### Description of the issue

The browser lost focus of the input because the children's ID was regenerated at each rerender. (if you had not defined a custom id)

I had to rename `useId` to `getId` because each function with `use` is considered has React Hook and we can't put a React Hook in a `useMemo`.

### Person(s) for reviewing proposed changes

@samuel-gomez @MartinWeb 

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
