### PR TITLE
fix(popover/help/helpinfo): help button contains two button, it desactivate the default onKeyPress 

### DIFF
--- a/packages/Form/Input/file/src/__tests__/__snapshots__/FileLine.spec.tsx.snap
+++ b/packages/Form/Input/file/src/__tests__/__snapshots__/FileLine.spec.tsx.snap
@@ -40,6 +40,8 @@ exports[`<File.FileInput> renders Preview correctly for type image 1`] = `
 <DocumentFragment>
   <div
     class="af-popover__wrapper"
+    role="button"
+    tabindex="0"
   >
     <div
       class="af-popover__container"

--- a/packages/Form/Input/file/src/__tests__/__snapshots__/FileLine.spec.tsx.snap
+++ b/packages/Form/Input/file/src/__tests__/__snapshots__/FileLine.spec.tsx.snap
@@ -39,7 +39,7 @@ exports[`<File.FileInput> renders Preview correctly for other type 1`] = `
 exports[`<File.FileInput> renders Preview correctly for type image 1`] = `
 <DocumentFragment>
   <div
-    class="af-popover__wrapper"
+    class="af-popover__wrapper af-popover__wrapper--over"
     role="button"
     tabindex="0"
   >

--- a/packages/help/src/Help.stories.tsx
+++ b/packages/help/src/Help.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { PopoverModes, PopoverPlacements } from '@axa-fr/react-toolkit-popover';
 import { Meta, Story } from '@storybook/react';
-import { PopoverPlacements, PopoverModes } from '@axa-fr/react-toolkit-popover';
-import Help from './Help';
+import React from 'react';
 import readme from '../README.md';
+import Help from './Help';
 import './help-custom.scss';
 
 export default {
@@ -43,6 +43,7 @@ const Template: Story<HelpProps> = ({ children, ...args }) => (
 export const TextStory: Story<HelpProps> = Template.bind({});
 TextStory.args = {
   children: 'Lorem ipsum dolor sit amet',
+  classModifier: 'circle',
   mode: PopoverModes.click,
   placement: PopoverPlacements.right,
 };

--- a/packages/help/src/Help.tsx
+++ b/packages/help/src/Help.tsx
@@ -1,9 +1,9 @@
-import React, { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { getComponentClassName } from '@axa-fr/react-toolkit-core';
 import Popover, {
   PopoverBase,
   PopoverPlacements,
 } from '@axa-fr/react-toolkit-popover';
-import { getComponentClassName } from '@axa-fr/react-toolkit-core';
+import React, { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 export type HelpProps = ComponentPropsWithoutRef<typeof Popover> & {
   helpButtonContent?: ReactNode;
@@ -31,9 +31,7 @@ const Help = ({
       mode={mode}>
       <PopoverBase.Pop>{children}</PopoverBase.Pop>
       <PopoverBase.Over>
-        <button className={buttonClassName} type="button">
-          {helpButtonContent}
-        </button>
+        <div className={buttonClassName}>{helpButtonContent}</div>
       </PopoverBase.Over>
     </Popover>
   );

--- a/packages/help/src/help-custom.scss
+++ b/packages/help/src/help-custom.scss
@@ -67,6 +67,8 @@
 }
 
 .af-popover__wrapper {
-  border-radius: 100vmax;
   outline-offset: 2px;
+  &:has(.af-popover__container--circle) {
+    border-radius: 100vmax;
+  }
 }

--- a/packages/help/src/help-custom.scss
+++ b/packages/help/src/help-custom.scss
@@ -1,7 +1,8 @@
 @import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
 
 .af-popover__container--custom {
-  margin-top: 50px;
+  margin-top: 25px;
+  margin-bottom: 25px;
 
   .af-popover {
     &__container-pop {
@@ -63,4 +64,9 @@
   font-style: italic;
   font-size: 1.2rem;
   vertical-align: middle;
+}
+
+.af-popover__wrapper {
+  border-radius: 100vmax;
+  outline-offset: 2px;
 }

--- a/packages/helpinfo/src/HelpInfo.stories.tsx
+++ b/packages/helpinfo/src/HelpInfo.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react';
-import { PopoverPlacements, PopoverModes } from '@axa-fr/react-toolkit-popover';
-import Button from '@axa-fr/react-toolkit-button';
 import Badge from '@axa-fr/react-toolkit-badge';
-import HelpInfo from './HelpInfo';
+import Button from '@axa-fr/react-toolkit-button';
+import { PopoverModes, PopoverPlacements } from '@axa-fr/react-toolkit-popover';
+import { Meta, Story } from '@storybook/react';
+import React from 'react';
 import readme from '../README.md';
+import HelpInfo from './HelpInfo';
 
 export default {
   title: 'Components high level/HelpInfo',
@@ -92,6 +92,7 @@ ButtonStory.args = {
 export const BadgeStory: Story<HelpProps> = Template.bind({});
 BadgeStory.args = {
   content: 'Nombre de notifications',
+  classModifier: 'circle',
   mode: PopoverModes.over,
   placement: PopoverPlacements.top,
   children: <Badge classModifier="error">5</Badge>,

--- a/packages/helpinfo/src/help-info.scss
+++ b/packages/helpinfo/src/help-info.scss
@@ -2,7 +2,6 @@
 
 .af-popover__wrapper:has(.af-popover__container--short) {
   position: relative;
-  display: block;
 }
 
 .af-popover__container--short {

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -95,9 +95,13 @@ const PopoverOver = ({
 
   return (
     <div
+      role="button"
+      tabIndex={0}
       className="af-popover__wrapper"
       onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}>
+      onMouseLeave={handleMouseLeave}
+      onFocus={handleMouseEnter}
+      onBlur={handleMouseLeave}>
       <PopoverBase
         isOpen={isOpen}
         placement={placement}

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -60,7 +60,7 @@ const PopoverClick = ({
       role="button"
       tabIndex={0}
       ref={wrapperRef}
-      className="af-popover__wrapper"
+      className="af-popover__wrapper af-popover__wrapper--click"
       onKeyDown={handleKeyDown}
       onClick={handleClick}
       onBlur={(event) => handleClick(event, false)}>
@@ -97,7 +97,7 @@ const PopoverOver = ({
     <div
       role="button"
       tabIndex={0}
-      className="af-popover__wrapper"
+      className="af-popover__wrapper af-popover__wrapper--over"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onFocus={handleMouseEnter}

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Constants } from '@axa-fr/react-toolkit-core';
+import React from 'react';
 import PopoverBase from './PopoverBase';
 import PopoverModes from './PopoverModes';
 import Placement from './PopoverPlacements';
@@ -23,38 +23,28 @@ const PopoverClick = ({
 }: Props) => {
   const wrapperRef = React.useRef(null);
   const [isOpen, setOpen] = React.useState(false);
-  const [isHover, setHover] = React.useState(false);
   const [isPopoverHover, setPopoverHover] = React.useState(false);
 
-  const handleClickOutside = (event: MouseEvent | React.MouseEvent) => {
-    if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
-      setOpen(false);
-      document.removeEventListener('click', handleClickOutside);
-    }
-  };
-
   const handleClick = (
-    event: MouseEvent | React.MouseEvent | React.KeyboardEvent<HTMLDivElement>
+    event:
+      | MouseEvent
+      | React.MouseEvent
+      | React.KeyboardEvent<HTMLDivElement>
+      | React.FocusEvent,
+    isOpenValue?: boolean
   ) => {
-    if (isPopoverHover) {
+    if (isPopoverHover || !wrapperRef.current || isOpenValue === isOpen) {
       event.stopPropagation();
       return;
     }
 
-    const shouldOpen = !isOpen && isHover;
-    setOpen(shouldOpen);
+    setOpen((oldIsOpen) => isOpenValue ?? !oldIsOpen);
+  };
 
-    if (shouldOpen) {
-      document.addEventListener('click', handleClickOutside);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter') {
+      handleClick(event);
     }
-  };
-
-  const handleMouseEnter = () => {
-    setHover(true);
-  };
-
-  const handleMouseLeave = () => {
-    setHover(false);
   };
 
   const handleMouseEnterPopover = () => {
@@ -71,10 +61,9 @@ const PopoverClick = ({
       tabIndex={0}
       ref={wrapperRef}
       className="af-popover__wrapper"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onKeyDown={handleClick}
-      onClick={handleClick}>
+      onKeyDown={handleKeyDown}
+      onClick={handleClick}
+      onBlur={(event) => handleClick(event, false)}>
       <PopoverBase
         onMouseEnter={handleMouseEnterPopover}
         onMouseLeave={handleMouseLeavePopover}

--- a/packages/popover/src/__tests__/Popover.spec.tsx
+++ b/packages/popover/src/__tests__/Popover.spec.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import Popover from '../Popover';
 
 describe('<Popover />', () => {
@@ -40,6 +40,81 @@ describe('<Popover />', () => {
         'af-popover__container-pop'
       );
     });
+
+    it('Should hide content when element reclicked', () => {
+      // Arrange
+      const { getByRole } = render(
+        <Popover mode="click">
+          <Popover.Pop>
+            <p>Modal content</p>
+          </Popover.Pop>
+          <Popover.Over>
+            <span>Source</span>
+          </Popover.Over>
+        </Popover>
+      );
+
+      userEvent.click(getByRole('presentation'));
+
+      expect(getByRole('presentation').nextElementSibling).toHaveClass(
+        'af-popover__container-pop'
+      );
+
+      userEvent.click(getByRole('presentation'));
+
+      expect(getByRole('presentation').nextElementSibling).toBeNull();
+    });
+
+    it('Should contain PopoverClick element when the "Enter" key is pressed and the button is focused', () => {
+      const { getByRole } = render(
+        <Popover mode="click">
+          <Popover.Pop>
+            <p>Modal content</p>
+          </Popover.Pop>
+          <Popover.Over>
+            <span>Source</span>
+          </Popover.Over>
+        </Popover>
+      );
+
+      const buttonElement = getByRole('button');
+      buttonElement.focus();
+
+      expect(buttonElement).toHaveFocus();
+
+      userEvent.keyboard('{Enter}');
+
+      expect(getByRole('presentation').nextElementSibling).toHaveClass(
+        'af-popover__container-pop'
+      );
+    });
+  });
+
+  it('Should hide PopoverClick element when the button loses focus', () => {
+    const { getByRole } = render(
+      <Popover mode="click">
+        <Popover.Pop>
+          <p>Modal content</p>
+        </Popover.Pop>
+        <Popover.Over>
+          <span>Source</span>
+        </Popover.Over>
+      </Popover>
+    );
+
+    const buttonElement = getByRole('button');
+    buttonElement.focus();
+
+    expect(buttonElement).toHaveFocus();
+
+    userEvent.keyboard('{Enter}');
+    expect(getByRole('presentation').nextElementSibling).toHaveClass(
+      'af-popover__container-pop'
+    );
+
+    userEvent.tab();
+    expect(buttonElement).not.toHaveFocus();
+    expect(getByRole('presentation').nextElementSibling).toBeNull();
   });
 
   describe('mode "hover"', () => {
@@ -83,6 +158,30 @@ describe('<Popover />', () => {
       );
     });
 
+    it('Should display content when element is focused', () => {
+      // Arrange
+      const { getByRole } = render(
+        <Popover mode="hover">
+          <Popover.Pop>
+            <p>Modal content</p>
+          </Popover.Pop>
+          <Popover.Over>
+            <span>Source</span>
+          </Popover.Over>
+        </Popover>
+      );
+
+      const buttonElement = getByRole('button');
+      buttonElement.focus();
+
+      expect(buttonElement).toHaveFocus();
+
+      // Assert
+      expect(getByRole('presentation').nextElementSibling).toHaveClass(
+        'af-popover__container-pop'
+      );
+    });
+
     it('Should hide content when element not hovered', () => {
       // Arrange
       const { getByRole } = render(
@@ -103,5 +202,33 @@ describe('<Popover />', () => {
       // Assert
       expect(getByRole('presentation').nextSibling).toBeNull();
     });
+  });
+
+  it('Should hide content when element loses focus', () => {
+    // Arrange
+    const { getByRole } = render(
+      <Popover mode="hover">
+        <Popover.Pop>
+          <p>Modal content</p>
+        </Popover.Pop>
+        <Popover.Over>
+          <span>Source</span>
+        </Popover.Over>
+      </Popover>
+    );
+
+    const buttonElement = getByRole('button');
+    buttonElement.focus();
+
+    expect(buttonElement).toHaveFocus();
+
+    expect(getByRole('presentation').nextElementSibling).toHaveClass(
+      'af-popover__container-pop'
+    );
+
+    userEvent.tab();
+
+    expect(buttonElement).not.toHaveFocus();
+    expect(getByRole('presentation').nextElementSibling).toBeNull();
   });
 });

--- a/packages/popover/src/help-custom.scss
+++ b/packages/popover/src/help-custom.scss
@@ -1,7 +1,8 @@
 @import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
 
 .af-popover__container--custom {
-  margin-top: 50px;
+  margin-top: 25px;
+  margin-bottom: 25px;
 
   .af-popover {
     &__container-pop {

--- a/packages/popover/src/popover.scss
+++ b/packages/popover/src/popover.scss
@@ -44,6 +44,10 @@ $padding-popover: 0.5rem 1rem;
       }
     }
 
+    .btn {
+      cursor: pointer;
+    }
+
     .af-popover__arrow {
       width: $arrow-size;
       height: $arrow-size;

--- a/packages/popover/src/popover.scss
+++ b/packages/popover/src/popover.scss
@@ -10,10 +10,13 @@ $padding-popover: 0.5rem 1rem;
     background: inherit;
     border: 0;
     padding: 0;
+
+    &--click {
+      cursor: pointer;
+    }
   }
 
   &__container {
-    cursor: initial;
     display: inline-block;
 
     &-pop {
@@ -42,10 +45,6 @@ $padding-popover: 0.5rem 1rem;
           height: 2rem;
         }
       }
-    }
-
-    .btn {
-      cursor: pointer;
     }
 
     .af-popover__arrow {


### PR DESCRIPTION
## Related issue

https://github.com/AxaFrance/react-toolkit/issues/1080

### Description of the issue

I removed the second button to improve accessibility.
It wasn't blocking the `onKeyPress` but the condition which required your cursor to be over the button to use the `onKeyPress`.

I changed a little bit the UX :

#### Before :
```
Activated when :
- button click / button hover
- button hover + button focus+ press any key

Deactivated when :
- button click / no button hover
- click away from button
- button hover+ button focus+ press any key
- lose button focus
```

#### Now :
```
Activated when :
- button click / button hover
- button focus + press "Enter" key

Deactivated when :
- button click / no button hover
- click away from button
- button focus + press "Enter" key
- lose button focus
```

I had `role="button"` on PopoverOver wrapper to be focusable.

I've made a few styling changes, so if you have any questions/suggestions about this don't hesitate.

### Person(s) for reviewing proposed changes

@samuel-gomez @MartinWeb 

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
