### PR TITLE
fix(storybook): steps stories name

### DIFF
--- a/packages/Form/steps/src/Steps.stories.tsx
+++ b/packages/Form/steps/src/Steps.stories.tsx
@@ -71,14 +71,14 @@ const Template: Story<StepsProps> = ({ classModifier, className, mode }) => (
   </Steps>
 );
 
-export const OldStepsStory = Template.bind({}) as typeof Template;
+export const NewStepsStory = Template.bind({}) as typeof Template;
 NewStepsStory.storyName = 'New Design Steps';
 NewStepsStory.args = {
   classModifier: '',
   className: 'af-steps-new',
 };
 
-export const NewStepsStory = Template.bind({}) as typeof Template;
+export const OldStepsStory = Template.bind({}) as typeof Template;
 OldStepsStory.storyName = 'Old Design Steps';
 OldStepsStory.args = {
   classModifier: '',

--- a/packages/Form/steps/src/Steps.stories.tsx
+++ b/packages/Form/steps/src/Steps.stories.tsx
@@ -72,15 +72,15 @@ const Template: Story<StepsProps> = ({ classModifier, className, mode }) => (
 );
 
 export const OldStepsStory = Template.bind({}) as typeof Template;
-OldStepsStory.storyName = 'Old Design Steps';
-OldStepsStory.args = {
+NewStepsStory.storyName = 'New Design Steps';
+NewStepsStory.args = {
   classModifier: '',
   className: 'af-steps-new',
 };
 
 export const NewStepsStory = Template.bind({}) as typeof Template;
-NewStepsStory.storyName = 'Old Design Steps';
-NewStepsStory.args = {
+OldStepsStory.storyName = 'Old Design Steps';
+OldStepsStory.args = {
   classModifier: '',
   className: '',
 };


### PR DESCRIPTION
Both steps stories have the same name.
![image](https://github.com/AxaFrance/react-toolkit/assets/1991349/db152ef9-2ac5-4118-9989-f9c69a24edc8)
