### PR TITLE
fix(Select): remove select option when defaultValue is defined

### DIFF
--- a/packages/Form/Input/select/src/Select.tsx
+++ b/packages/Form/Input/select/src/Select.tsx
@@ -1,6 +1,6 @@
-import React, { ComponentPropsWithRef, useState } from 'react';
 import { useId } from '@axa-fr/react-toolkit-core';
 import { withInput } from '@axa-fr/react-toolkit-form-core';
+import React, { ComponentPropsWithRef, useMemo, useState } from 'react';
 import SelectBase from './SelectBase';
 
 type Props = ComponentPropsWithRef<typeof SelectBase> & {
@@ -20,9 +20,13 @@ const SelectDefault = ({
 }: Props) => {
   const [hasHandleChangeOnce, setHasHandleChangeOnce] = useState(false);
 
-  const newOptions = hasHandleChangeOnce
-    ? options
-    : [{ value: '', label: placeholder }, ...options];
+  const newOptions = useMemo(
+    () =>
+      hasHandleChangeOnce || otherProps.defaultValue !== undefined
+        ? options
+        : [{ value: '', label: placeholder }, ...options],
+    [hasHandleChangeOnce, options, otherProps.defaultValue, placeholder]
+  );
 
   const inputId = useId(id);
 


### PR DESCRIPTION
## Related issue

### Reference to the issue

https://github.com/AxaFrance/react-toolkit/issues/1188

### Description of the issue

`Remove "- Select -" option when a default value is defined`
