### PR TITLE
feat: mark old step form design as deprecated

### DIFF
--- a/packages/Form/steps/src/Steps.stories.tsx
+++ b/packages/Form/steps/src/Steps.stories.tsx
@@ -79,7 +79,7 @@ NewStepsStory.args = {
 };
 
 export const OldStepsStory = Template.bind({}) as typeof Template;
-OldStepsStory.storyName = 'Old Design Steps';
+OldStepsStory.storyName = 'Old Design Steps (Deprecated)';
 OldStepsStory.args = {
   classModifier: '',
   className: '',

--- a/packages/Form/steps/src/step-form.scss
+++ b/packages/Form/steps/src/step-form.scss
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Please use 'step-form-new.css' instead!
+ */
 @import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
 
 // Wizard Steps


### PR DESCRIPTION
Mark old step form design as deprecated.
![image](https://github.com/AxaFrance/react-toolkit/assets/1991349/afd83bff-c985-476d-98b3-0771d71ed7c9)
It shouldn't be used anymore.